### PR TITLE
Fix regex patterns in API to correctly parse SEO metrics from issues

### DIFF
--- a/app/api/github/stats/route.ts
+++ b/app/api/github/stats/route.ts
@@ -106,9 +106,9 @@ export async function GET() {
     }
 
     if (latestSeoReport?.body) {
-      const posMatch = latestSeoReport.body.match(/Predicted Position:\*\*\s*([\d.]+)/);
-      const readMatch = latestSeoReport.body.match(/Readability:\*\*\s*([\d.]+)\/100/);
-      const eeatMatch = latestSeoReport.body.match(/E-E-A-T Score:\*\*\s*([\d.]+)\/100/);
+      const posMatch = latestSeoReport.body.match(/\*\*Predicted Position:\*\*\s*([\d.]+)/);
+      const readMatch = latestSeoReport.body.match(/\*\*Readability:\*\*\s*([\d.]+)\/100/);
+      const eeatMatch = latestSeoReport.body.match(/\*\*E-E-A-T Score:\*\*\s*([\d.]+)\/100/);
 
       if (posMatch) predictedPosition = parseFloat(posMatch[1]);
       if (readMatch) readability = parseFloat(readMatch[1]);


### PR DESCRIPTION
The regex patterns were looking for markdown bold markers after the field names (e.g. 'Predicted Position:**') but the actual format has them before (e.g. '**Predicted Position:**').

Updated patterns:
- **Predicted Position:** (was: Predicted Position:**)
- **Readability:** (was: Readability:**)
- **E-E-A-T Score:** (was: E-E-A-T Score:**)

This fixes admin panel not displaying SEO metrics correctly.